### PR TITLE
Add getLastLocation with onError instead of onComplete

### DIFF
--- a/library/src/main/java/com/patloew/rxlocation/FusedLocation.java
+++ b/library/src/main/java/com/patloew/rxlocation/FusedLocation.java
@@ -62,6 +62,11 @@ public class FusedLocation {
         return Maybe.create(new LocationLastMaybeOnSubscribe(rxLocation));
     }
 
+    @RequiresPermission(anyOf = {Manifest.permission.ACCESS_COARSE_LOCATION, Manifest.permission.ACCESS_FINE_LOCATION})
+    public Maybe<Location> lastLocationOf() {
+        return Maybe.create(new LocationLastMaybeOfOnSubscribe(rxLocation));
+    }
+
 
     // Location Availability
 

--- a/library/src/main/java/com/patloew/rxlocation/LocationLastMaybeOfOnSubscribe.java
+++ b/library/src/main/java/com/patloew/rxlocation/LocationLastMaybeOfOnSubscribe.java
@@ -1,0 +1,26 @@
+package com.patloew.rxlocation;
+
+import android.location.Location;
+import android.support.annotation.NonNull;
+import com.google.android.gms.common.api.GoogleApiClient;
+import com.google.android.gms.location.LocationServices;
+import io.reactivex.MaybeEmitter;
+
+class LocationLastMaybeOfOnSubscribe extends RxLocationMaybeOnSubscribe<Location> {
+
+  LocationLastMaybeOfOnSubscribe(@NonNull RxLocation rxLocation) {
+    super(rxLocation, null, null);
+  }
+
+  @Override
+  protected void onGoogleApiClientReady(GoogleApiClient apiClient, MaybeEmitter<Location> emitter) {
+    //noinspection MissingPermission
+    Location location = LocationServices.FusedLocationApi.getLastLocation(apiClient);
+
+    if (location != null) {
+      emitter.onSuccess(location);
+    } else {
+      emitter.onError(new LocationUnavailableException());
+    }
+  }
+}

--- a/library/src/main/java/com/patloew/rxlocation/LocationUnavailableException.java
+++ b/library/src/main/java/com/patloew/rxlocation/LocationUnavailableException.java
@@ -1,0 +1,13 @@
+package com.patloew.rxlocation;
+
+/**
+ * Exception to indicate that location is not available.
+ */
+public class LocationUnavailableException extends Throwable {
+    public LocationUnavailableException(String message) {
+        super(message);
+    }
+
+    public LocationUnavailableException() {
+    }
+}

--- a/library/src/test/java/com/patloew/rxlocation/LocationOnSubscribeTest.java
+++ b/library/src/test/java/com/patloew/rxlocation/LocationOnSubscribeTest.java
@@ -128,6 +128,29 @@ public class LocationOnSubscribeTest extends BaseOnSubscribeTest {
         assertNoValue(Maybe.create(maybe).test());
     }
 
+    @Test
+    public void LocationLastMaybeOf_Success() {
+        LocationLastMaybeOfOnSubscribe maybe = PowerMockito.spy(new LocationLastMaybeOfOnSubscribe(rxLocation));
+
+        Location location = Mockito.mock(Location.class);
+        when(fusedLocationProviderApi.getLastLocation(apiClient)).thenReturn(location);
+
+        setupBaseMaybeSuccess(maybe);
+
+        assertSingleValue(Maybe.create(maybe).test(), location);
+    }
+
+    @Test
+    public void LocationLastMaybeOf_Null_Error() {
+        LocationLastMaybeOfOnSubscribe maybe = PowerMockito.spy(new LocationLastMaybeOfOnSubscribe(rxLocation));
+
+        when(fusedLocationProviderApi.getLocationAvailability(apiClient)).thenReturn(null);
+
+        setupBaseMaybeSuccess(maybe);
+
+        assertError(Maybe.create(maybe).test(), LocationUnavailableException.class);
+    }
+
     // LocationRemoveUpdatesSingle
 
     @Test

--- a/library/src/test/java/com/patloew/rxlocation/LocationTest.java
+++ b/library/src/test/java/com/patloew/rxlocation/LocationTest.java
@@ -80,6 +80,19 @@ public class LocationTest extends BaseTest {
     }
 
     @Test
+    public void LastLocationOf() throws Exception {
+        ArgumentCaptor<LocationLastMaybeOfOnSubscribe> captor = ArgumentCaptor.forClass(LocationLastMaybeOfOnSubscribe.class);
+
+        rxLocation.location().lastLocationOf();
+
+        PowerMockito.verifyStatic(times(1));
+        Maybe.create(captor.capture());
+
+        LocationLastMaybeOfOnSubscribe single = captor.getAllValues().get(0);
+        assertNoTimeoutSet(single);
+    }
+
+    @Test
     public void LocationAvailable() throws Exception {
         ArgumentCaptor<LocationAvailabilitySingleOnSubscribe> captor = ArgumentCaptor.forClass(LocationAvailabilitySingleOnSubscribe.class);
 


### PR DESCRIPTION
There are situations where I want to issue an error and in my case is this not possible with onComplete.