### PR TITLE
Add the source code compatibility info to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,17 @@ dependencies {
 }
 ```
 
-From v1.0.4 on, RxLocation only works with Android gradle plugin 3.0.0 or higher, since it uses Java 8 language features.
+From v1.0.4 on, RxLocation only works with Android gradle plugin 3.0.0 or higher, since it uses Java 8 language features.  
+And don't forget to set the source code compatibility to Java 8:
+
+```groovy
+android {
+  compileOptions {
+    sourceCompatibility JavaVersion.VERSION_1_8
+    targetCompatibility JavaVersion.VERSION_1_8
+  }
+}
+```
 
 # Testing
 


### PR DESCRIPTION
As said here https://developer.android.com/studio/write/java8-support.html, we need to add this even if we use Java 8 features through dependencies:
```groovy
android {
  ...
  // Configure only for each module that uses Java 8
  // language features (either in its source code or
  // through dependencies).
  compileOptions {
    sourceCompatibility JavaVersion.VERSION_1_8
    targetCompatibility JavaVersion.VERSION_1_8
  }
}
```