### PR TITLE
Remove app name and use new dependency keywords

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,9 @@
 language: android
 jdk:
   - oraclejdk8
-android:
-  components:
-    # Uncomment the lines below if you want to
-    # use the latest revision of Android SDK Tools
-    - platform-tools
-    - tools
-
-    # The BuildTools version used by your project
-    - build-tools-26.0.3
-
-    # The SDK version used to compile your project
-    - android-26
-
-    # Additional components
-    - extra-google-google_play_services
-    - extra-google-m2repository
-    - extra-android-m2repository
-
 before_install:
+  - mkdir "$ANDROID_HOME/licenses" || true
+  - echo "d56f5187479451eabf01fb78af6dfcb131a6481e" > "$ANDROID_HOME/licenses/android-sdk-license"
   - export JAVA8_HOME=/usr/lib/jvm/java-8-oracle
   - export JAVA_HOME=$JAVA8_HOME
 after_success:

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
         classpath "com.github.dcendents:android-maven-gradle-plugin:1.5"

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -8,12 +8,11 @@ version = '1.0.4'
 project.archivesBaseName = 'rxlocation'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "26.0.3"
+    compileSdkVersion 27
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 26
+        targetSdkVersion 27
         versionCode 4
         versionName "1.0.4"
     }
@@ -37,14 +36,13 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'io.reactivex.rxjava2:rxjava:2.1.6'
-    compile 'com.google.android.gms:play-services-location:10.2.1'
+    api 'io.reactivex.rxjava2:rxjava:2.1.7'
+    api 'com.google.android.gms:play-services-location:11.6.2'
 
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.mockito:mockito-core:2.11.0'
-    testCompile "org.powermock:powermock-module-junit4:2.0.0-beta.5"
-    testCompile "org.powermock:powermock-api-mockito2:2.0.0-beta.5"
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.mockito:mockito-core:2.11.0'
+    testImplementation "org.powermock:powermock-module-junit4:2.0.0-beta.5"
+    testImplementation "org.powermock:powermock-api-mockito2:2.0.0-beta.5"
 }
 
 task generateSourcesJar(type: Jar) {

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.patloew.rxlocation">
 
-    <application android:label="@string/app_name">
+    <application>
 
         <activity
             android:name="com.patloew.rxlocation.LocationSettingsActivity"

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -1,5 +1,4 @@
 <resources>
-    <string name="app_name">RxLocation</string>
 
     <string name="define_rxlocation"></string>
     <!-- Author section -->

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,8 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "26.0.3"
+    compileSdkVersion 27
 
     defaultConfig {
         applicationId "com.patloew.rxlocationsample"
@@ -29,29 +28,30 @@ android {
     }
 }
 
+ext {
+    supportLibVersion = '27.0.2'
+}
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:26.1.0'
-    compile 'com.android.support:support-v4:26.1.0'
-    compile "com.android.support:design:26.1.0"
-    compile "com.android.support:cardview-v7:26.1.0"
+    implementation "com.android.support:appcompat-v7:$supportLibVersion"
+    implementation "com.android.support:support-v4:$supportLibVersion"
+    implementation "com.android.support:design:$supportLibVersion"
+    implementation "com.android.support:cardview-v7:$supportLibVersion"
 
-    compile project(':library')
+    implementation project(':library')
     //compile 'com.patloew.rxlocation:rxlocation:1.0.4'
 
-    compile 'io.reactivex.rxjava2:rxandroid:2.0.1'
-    compile 'io.reactivex.rxjava2:rxjava:2.1.6'
+    implementation 'io.reactivex.rxjava2:rxandroid:2.0.1'
+    implementation 'io.reactivex.rxjava2:rxjava:2.1.7'
 
-    compile 'com.google.android.gms:play-services-location:11.6.0'
+    implementation 'com.google.android.gms:play-services-location:11.6.2'
 
-    compile('com.mikepenz:aboutlibraries:5.9.4@aar') {
+    implementation('com.mikepenz:aboutlibraries:5.9.4@aar') {
         transitive = true
     }
 
-    debugCompile 'com.squareup.leakcanary:leakcanary-android:1.5.4'
-    releaseCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.5.4'
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android:1.5.4'
+    releaseImplementation 'com.squareup.leakcanary:leakcanary-android-no-op:1.5.4'
 
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.mockito:mockito-core:2.11.0'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.mockito:mockito-core:2.11.0'
 }


### PR DESCRIPTION
Started this PR to remove the `app_name` string since it conflicts with the apps that use this library. 

Updated to change `compile` to `implementation` and `api` where appropriate. 

Updated some versions as well while I was at it